### PR TITLE
Refactor cosypose wrapper

### DIFF
--- a/happypose/pose_estimators/cosypose/cosypose/utils/cosypose_wrapper.py
+++ b/happypose/pose_estimators/cosypose/cosypose/utils/cosypose_wrapper.py
@@ -60,7 +60,7 @@ AVAILABLE_MODELS = {
         },
     },
     "ycbv": {
-        "ycbv": {
+        "pbr": {
             "detector_run_id": "detector-bop-ycbv-pbr--970850",
             "coarse_run_id": "coarse-bop-ycbv-pbr--724183",
             "refiner_run_id": "refiner-bop-ycbv-pbr--604090",

--- a/happypose/pose_estimators/cosypose/cosypose/utils/cosypose_wrapper.py
+++ b/happypose/pose_estimators/cosypose/cosypose/utils/cosypose_wrapper.py
@@ -84,11 +84,13 @@ class CosyPoseWrapper:
         n_workers: int = 8,
     ) -> None:
         """
-        :param dataset_name: str, name of the dataset on which model was trained, hope|tless|ycbv
-        :param model_type: str, type of NN model (depends on training data), hope|tless|ycbv
-        :param object_dataset: None or already existing rigid object dataset. If None, will use dataset_name to build one
-        :param n_workers: how many processes will be spun in the batch renderer
-        :param renderer_type: 'panda3d'|'bullet'
+        Args:
+        ----
+            dataset_name: str, name of the dataset on which model was trained, hope|tless|ycbv
+            model_type: str, type of NN model (depends on training data), hope|tless|ycbv
+            object_dataset: RigidObjectDataset, None or already existing rigid object dataset. If None, will use dataset_name to build one.
+            n_workers: int, how many processes will be spun in the batch renderer
+            renderer_type: str 'panda3d'|'bullet'
         """
 
         self.dataset_name = dataset_name
@@ -100,15 +102,18 @@ class CosyPoseWrapper:
     def get_model(
         self, dataset_name, model_type, n_workers, renderer_type
     ) -> Tuple[Detector, PoseEstimator]:
-        """
-        Return CosyPose detector and pose estimator objects for a given dataset.
+        """Return CosyPose detector and pose estimator objects for a given dataset.
 
-        :param dataset_name: str, name of the dataset on which model was trained, hope|tless|ycbv
-        :param model_type: str, type of NN model (depends on training data), hope|tless|ycbv
-        :param renderer_type: str, which renderer to use, "panda3d" and "bullet" supported
-        :param n_workers: int, number of workers used in the renderer
-        :param model_type: str, what training data was used, "pbr" and "synth+real" supported
-        :return: tuple (Detector,PoseEstimator)
+        Args:
+        ----
+            dataset_name: str, name of the dataset on which model was trained, hope|tless|ycbv
+            model_type: str, type of NN model (depends on training data), hope|tless|ycbv
+            renderer_type: str, which renderer to use, "panda3d" and "bullet" supported
+            n_workers: int, number of workers used in the renderer
+            model_type: str, what training data was used, "pbr" and "synth+real" supported
+        Returns:
+        -------
+            tuple (Detector,PoseEstimator)
         """
         try:
             mids = AVAILABLE_MODELS[dataset_name][model_type]

--- a/happypose/pose_estimators/cosypose/cosypose/utils/cosypose_wrapper.py
+++ b/happypose/pose_estimators/cosypose/cosypose/utils/cosypose_wrapper.py
@@ -90,7 +90,7 @@ class CosyPoseWrapper:
         Args:
         ----
             dataset_name: str, name of the dataset on which model was trained, hope|tless|ycbv
-            model_type: str, type of NN model (depends on training data), hope|tless|ycbv
+            model_type: str, type of NN model (depends on training data), pbr|synth+real
             object_dataset: RigidObjectDataset, None or already existing rigid object dataset. If None, will use dataset_name to build one.
             n_workers: int, how many processes will be spun in the batch renderer
             renderer_type: str 'panda3d'|'bullet'
@@ -110,7 +110,7 @@ class CosyPoseWrapper:
         Args:
         ----
             dataset_name: str, name of the dataset on which model was trained, hope|tless|ycbv
-            model_type: str, type of NN model (depends on training data), hope|tless|ycbv
+            model_type: str, type of NN model (depends on training data), pbr|synth+real
             renderer_type: str, which renderer to use, "panda3d" and "bullet" supported
             n_workers: int, number of workers used in the renderer
             model_type: str, what training data was used, "pbr" and "synth+real" supported
@@ -180,7 +180,7 @@ class CosyPoseWrapper:
         return coarse_model, refiner_model
 
     def inference(self, observation: ObservationTensor):
-        """Example of how to un inference with the loaded models.
+        """Example of how to use inference with the loaded models.
 
         Args:
         ---

--- a/happypose/pose_estimators/cosypose/cosypose/utils/cosypose_wrapper.py
+++ b/happypose/pose_estimators/cosypose/cosypose/utils/cosypose_wrapper.py
@@ -25,6 +25,9 @@ from happypose.pose_estimators.cosypose.cosypose.training.pose_models_cfg import
     load_model_cosypose,
 )
 from happypose.pose_estimators.megapose.inference.detector import Detector
+from happypose.pose_estimators.megapose.inference.types import (
+    ObservationTensor,
+)
 from happypose.toolbox.datasets.datasets_cfg import make_object_dataset
 from happypose.toolbox.datasets.object_dataset import RigidObjectDataset
 from happypose.toolbox.inference.utils import load_detector
@@ -176,26 +179,20 @@ class CosyPoseWrapper:
         )
         return coarse_model, refiner_model
 
-    def inference(self, observation, coarse_guess=None):
-        detections = None
-        run_detector = True
-        if coarse_guess is None:
-            final_preds, all_preds = self.pose_predictor.run_inference_pipeline(
-                observation,
-                detections=detections,
-                run_detector=run_detector,
-                data_TCO_init=None,
-                n_coarse_iterations=1,
-                n_refiner_iterations=4,
-            )
-        else:
-            final_preds, all_preds = self.pose_predictor.run_inference_pipeline(
-                observation,
-                detections=detections,
-                run_detector=run_detector,
-                data_TCO_init=None,
-                n_coarse_iterations=0,
-                n_refiner_iterations=4,
-            )
+    def inference(self, observation: ObservationTensor):
+        """Example of how to un inference with the loaded models.
+
+        Args:
+        ---
+            observation: ObservationTensor, the data used for inference
+        """
+        final_preds, all_preds = self.pose_predictor.run_inference_pipeline(
+            observation,
+            detections=None,
+            run_detector=None,
+            data_TCO_init=None,
+            n_coarse_iterations=1,
+            n_refiner_iterations=4,
+        )
         print("inference successfull")
         return final_preds.cpu()


### PR DESCRIPTION
In CosyPoseWrapper class
- add a `model_type` "pbr" and "synth+real" model weights
- list available models ids for both "pbr" and "synth+real" model weights 
- does not change current default behavior (load "pbr" models)
- remove unused argument gpu_renderer
- simplify unused function `inference`