### PR TITLE
drop conda/mamba/mini broken nonsense

### DIFF
--- a/.github/workflows/conda-test.yml
+++ b/.github/workflows/conda-test.yml
@@ -31,9 +31,6 @@ jobs:
         with:
           activate-environment: happypose
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          use-mamba: true
 
       - name: Get date for caching, reset cache every day
         id: get-date
@@ -54,7 +51,7 @@ jobs:
         id: cache
 
       - name: Update conda environment with happypose dependencies
-        run: mamba env update -n happypose -f environment.yml
+        run: conda env update -n happypose -f environment.yml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install happypose


### PR DESCRIPTION
Fix CI which currently fails with:
```
  Can we use bundled Miniconda?
  Can we download a custom installer by URL?
  Can we download Miniforge?
  ... will download Miniforge.
  Will fetch Mambaforge latest from https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
  Ensuring Installer...
  Checking for cached Mambaforge@latest...
  Did not find Mambaforge-Linux-x86_64.sh latest in cache
Error: Unexpected HTTP response: 404
```